### PR TITLE
feat: added `trim`, `trim_start`, and `trim_end` filters (for #73)

### DIFF
--- a/book/templates/expressions/filters.md
+++ b/book/templates/expressions/filters.md
@@ -68,6 +68,9 @@ use crate::filters_for_oxiplate;
 | Filter | Description |
 |-|-|
 | `lower` | Converts to lowercase |
+| `trim` | Trims leading and trailing whitespace |
+| `trim_end` | Trims trailing whitespace |
+| `trim_start` | Trims leading whitespace |
 | `upper` | Converts to uppercase |
 
 ### `Option` filters

--- a/oxiplate/src/filters/mod.rs
+++ b/oxiplate/src/filters/mod.rs
@@ -51,8 +51,10 @@
 
 mod default;
 mod lower;
+mod trim;
 mod upper;
 
 pub use default::default;
 pub use lower::lower;
+pub use trim::{trim, trim_end, trim_start};
 pub use upper::upper;

--- a/oxiplate/src/filters/trim.rs
+++ b/oxiplate/src/filters/trim.rs
@@ -1,0 +1,119 @@
+use std::borrow::Cow;
+#[cfg(test)]
+use std::fmt::Display;
+
+use oxiplate_traits::CowStr;
+#[cfg(test)]
+use oxiplate_traits::{ToCowStr, cow_str_wrapper};
+
+/// Trims the leading and trailing whitespace from the input.
+///
+/// ```
+/// use std::fmt::Error;
+///
+/// use oxiplate::prelude::*;
+///
+/// #[derive(Oxiplate)]
+/// #[oxiplate_inline(html: r#"{{ >"  hello world   " | trim() }}"#)]
+/// struct Data;
+///
+/// fn main() -> Result<(), Error> {
+///     assert_eq!(Data.render()?, "hello world");
+///     Ok(())
+/// }
+/// ```
+pub fn trim<'a, E: CowStr<'a>>(expression: E) -> Cow<'a, str> {
+    match expression.cow_str() {
+        Cow::Borrowed(str) => str.trim().into(),
+        Cow::Owned(string) => Cow::Owned(string.trim().into()),
+    }
+}
+
+/// Trims the leading whitespace from the input.
+///
+/// ```
+/// use std::fmt::Error;
+///
+/// use oxiplate::prelude::*;
+///
+/// #[derive(Oxiplate)]
+/// #[oxiplate_inline(html: r#"{{ >"  hello world   " | trim_start() }}"#)]
+/// struct Data;
+///
+/// fn main() -> Result<(), Error> {
+///     assert_eq!(Data.render()?, "hello world   ");
+///     Ok(())
+/// }
+/// ```
+pub fn trim_start<'a, E: CowStr<'a>>(expression: E) -> Cow<'a, str> {
+    match expression.cow_str() {
+        Cow::Borrowed(str) => str.trim_start().into(),
+        Cow::Owned(string) => Cow::Owned(string.trim_start().into()),
+    }
+}
+/// Trims the trailing whitespace from the input.
+///
+/// ```
+/// use std::fmt::Error;
+///
+/// use oxiplate::prelude::*;
+///
+/// #[derive(Oxiplate)]
+/// #[oxiplate_inline(html: r#"{{ >"  hello world   " | trim_end() }}"#)]
+/// struct Data;
+///
+/// fn main() -> Result<(), Error> {
+///     assert_eq!(Data.render()?, "  hello world");
+///     Ok(())
+/// }
+/// ```
+pub fn trim_end<'a, E: CowStr<'a>>(expression: E) -> Cow<'a, str> {
+    match expression.cow_str() {
+        Cow::Borrowed(str) => str.trim_end().into(),
+        Cow::Owned(string) => Cow::Owned(string.trim_end().into()),
+    }
+}
+
+macro_rules! test {
+    ($test_fn:ident, $input:literal, $trim_fn:ident, $expected:literal) => {
+        #[test]
+        fn $test_fn() {
+            assert_eq!(
+                $expected,
+                $trim_fn(cow_str_wrapper!($input)),
+                "testing string slice"
+            );
+            assert_eq!(
+                $expected,
+                $trim_fn(cow_str_wrapper!(String::from($input))),
+                "testing `String`"
+            );
+
+            struct Data;
+            impl Display for Data {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    f.write_str($input)
+                }
+            }
+            assert_eq!(
+                $expected,
+                $trim_fn(cow_str_wrapper!(Data)),
+                "testing `Display`"
+            );
+        }
+    };
+}
+
+test!(test_trim, "\t\n Hello world!\t \n", trim, "Hello world!");
+test!(
+    test_trim_start,
+    "\t\n Hello world!\t \n",
+    trim_start,
+    "Hello world!\t \n"
+);
+test!(
+    test_trim_end,
+    "\t\n Hello world!\t \n",
+    trim_end,
+    "\t\n Hello world!"
+);


### PR DESCRIPTION
Filters to trim leading and/or trailing whitespace