### PR TITLE
Expand MSRV to a lower version of Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "colored",
  "oxiplate-derive",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-array"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-array-of-tables"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-bad-hex"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-double-assign"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-double-table"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-eof-in-string"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-escaper-bool"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-escaper-group-non-ident"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-escaper-group-non-path"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-escaper-group-relative"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-escaper-group-value"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-escaper-table"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-fallback-escaper-group-bool"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-infer-escaper-group-from-file-extension-string"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-missing-value"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-newline-in-string"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-newline-in-string-unclosed-string"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-newline-instead-of-value"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-number-escaper"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-optimized-renderer-string"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-overwriting-value-with-table"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-overwriting-value-with-table-via-ancestor"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-require-specifying-escaper-string"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-template"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-unexpected-escape-sequence"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-unexpected-escape-sequence-unclosed-string"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-unmatched-bracket"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-unrecognized-key"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-unsupported-brace"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-config-value-after-table-declaration"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-optimized-renderer"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-unreachable"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-derive-test-unreachable-stable"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate-derive",
  "trybuild",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-config-with-feature-turned-off"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-default-html"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-default-json"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-default-raw"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-escaper-without-config"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-escaper-without-default-escaper-group"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-fallback-group-malformed"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-fast-escape-type-priority"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-file-extension-inferrence-off"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-require-specifying-escaper"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-slow-escape-ints"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-template-dir-absolute"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-template-dir-file"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-template-dir-missing"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-template-dir-symlink"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-unreachable"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "oxiplate-test-unreachable-stable"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "oxiplate",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["escaping", "whitespace-control", "compile-time"]
 license = "MIT"
 edition = "2021"
 # Found with `cargo msrv --workspace find --ignore-lockfile`
-rust-version = "1.79.0"
+rust-version = "1.78.0"
 
 [workspace.lints.clippy]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["escaping", "whitespace-control", "compile-time"]
 license = "MIT"
 edition = "2021"
 # Found with `cargo msrv --workspace find --ignore-lockfile`
-rust-version = "1.75.0"
+rust-version = "1.74.1"
 
 [workspace.lints.clippy]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["escaping", "whitespace-control", "compile-time"]
 license = "MIT"
 edition = "2021"
 # Found with `cargo msrv --workspace find --ignore-lockfile`
-rust-version = "1.82.0"
+rust-version = "1.79.0"
 
 [workspace.lints.clippy]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["escaping", "whitespace-control", "compile-time"]
 license = "MIT"
 edition = "2021"
 # Found with `cargo msrv --workspace find --ignore-lockfile`
-rust-version = "1.78.0"
+rust-version = "1.75.0"
 
 [workspace.lints.clippy]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ repository = "https://github.com/0b10011/oxiplate"
 categories = ["template-engine"]
 keywords = ["escaping", "whitespace-control", "compile-time"]
 license = "MIT"
-edition = "2024"
-# Found with `cargo msrv --workspace find --no-default-features --features config,built-in-escapers,fast-escape-ints`
-rust-version = "1.85.1"
+edition = "2021"
+# Found with `cargo msrv --workspace find --ignore-lockfile`
+rust-version = "1.82.0"
 
 [workspace.lints.clippy]
 

--- a/book.toml
+++ b/book.toml
@@ -6,7 +6,7 @@ src = "book"
 title = "Oxiplate Documentation"
 
 [rust]
-edition = "2024"
+edition = "2021"
 
 [build]
 build-dir = "book-output"

--- a/oxiplate-derive/src/config/parser.rs
+++ b/oxiplate-derive/src/config/parser.rs
@@ -3,7 +3,7 @@ use std::mem;
 
 use crate::config::tokenizer::TokenKind;
 use crate::config::{Config, EscaperGroup, InferEscaperGroupFromFileExtension, Token, TokenSlice};
-use crate::parser::{Error, Parser as _, alt, cut, into, many0, opt, parse_all, take};
+use crate::parser::{alt, cut, into, many0, opt, parse_all, take, Error, Parser as _};
 use crate::{OptimizedRenderer, Source};
 
 type Res<'a, S> = crate::parser::Res<'a, TokenKind, S>;

--- a/oxiplate-derive/src/config/tokenizer/mod.rs
+++ b/oxiplate-derive/src/config/tokenizer/mod.rs
@@ -1,7 +1,7 @@
 pub use self::kind::TokenKind;
 use super::Token;
-use crate::Source;
 use crate::tokenizer::{BufferedSource, Eof, UnexpectedTokenError};
+use crate::Source;
 
 type Res<'a> = Result<Token<'a>, UnexpectedTokenError<'a>>;
 

--- a/oxiplate-derive/src/lib.rs
+++ b/oxiplate-derive/src/lib.rs
@@ -33,8 +33,8 @@ use crate::config::OptimizedRenderer;
 pub(crate) use crate::source::Source;
 use crate::source::SourceOwned;
 pub(crate) use crate::state::State;
-use crate::state::{LocalVariables, build_config};
-use crate::template::{TokenSlice, parse, tokens_and_eof};
+use crate::state::{build_config, LocalVariables};
+use crate::template::{parse, tokens_and_eof, TokenSlice};
 
 type BuiltTokens = (proc_macro2::TokenStream, usize);
 

--- a/oxiplate-derive/src/parser/context.rs
+++ b/oxiplate-derive/src/parser/context.rs
@@ -44,11 +44,11 @@ where
     fn parse(&self, tokens: TokenSlice<'a, K>) -> Res<'a, K, Self::Output> {
         match self.parser.parse(tokens) {
             value @ Ok(_) => value,
-            Err(err @ Error::Unrecoverable { is_eof, .. }) => Err(Error::Unrecoverable {
+            Err(err @ Error::Unrecoverable { .. }) => Err(Error::Unrecoverable {
                 message: self.message.to_string(),
                 source: err.source().clone(),
+                is_eof: err.is_eof(),
                 previous_error: Some(Box::new(err)),
-                is_eof,
             }),
             Err(err) => Err(Error::Recoverable {
                 message: self.message.to_string(),

--- a/oxiplate-derive/src/parser/mod.rs
+++ b/oxiplate-derive/src/parser/mod.rs
@@ -22,8 +22,8 @@ pub use opt::opt;
 pub use parse_all::parse_all;
 pub use take::take;
 
-use crate::Source;
 use crate::tokenizer::{TokenSlice, UnexpectedTokenError};
+use crate::Source;
 
 pub type Res<'a, K, S> = Result<(TokenSlice<'a, K>, S), Error<'a>>;
 

--- a/oxiplate-derive/src/state.rs
+++ b/oxiplate-derive/src/state.rs
@@ -2,13 +2,13 @@ use std::collections::{HashMap, HashSet, VecDeque};
 #[cfg(not(feature = "config"))]
 use std::fs;
 
-use syn::DeriveInput;
 use syn::spanned::Spanned;
+use syn::DeriveInput;
 
-use crate::BuiltTokens;
 #[cfg(not(feature = "config"))]
 use crate::config::config_path;
-use crate::config::{Config, EscaperGroup, OptimizedRenderer, read_config};
+use crate::config::{read_config, Config, EscaperGroup, OptimizedRenderer};
+use crate::BuiltTokens;
 
 #[cfg(all(feature = "built-in-escapers", not(feature = "oxiplate")))]
 compile_error!(

--- a/oxiplate-derive/src/template/mod.rs
+++ b/oxiplate-derive/src/template/mod.rs
@@ -4,4 +4,4 @@ mod tokenizer;
 pub(crate) use self::parser::parse;
 #[cfg(test)]
 pub use self::tokenizer::TokenKind;
-pub use self::tokenizer::{TokenSlice, tokens_and_eof};
+pub use self::tokenizer::{tokens_and_eof, TokenSlice};

--- a/oxiplate-derive/src/template/parser/comment.rs
+++ b/oxiplate-derive/src/template/parser/comment.rs
@@ -1,6 +1,6 @@
-use super::Item;
 use super::item::tag_end;
-use crate::parser::{Parser as _, cut, many0, take};
+use super::Item;
+use crate::parser::{cut, many0, take, Parser as _};
 use crate::template::parser::Res;
 use crate::template::tokenizer::{TagKind, TokenKind};
 use crate::{Source, TokenSlice};

--- a/oxiplate-derive/src/template/parser/expression/arguments.rs
+++ b/oxiplate-derive/src/template/parser/expression/arguments.rs
@@ -2,10 +2,10 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
 
 use super::Res;
-use crate::parser::{Parser as _, cut, many0, opt, take};
-use crate::template::parser::expression::{ExpressionAccess, expression};
+use crate::parser::{cut, many0, opt, take, Parser as _};
+use crate::template::parser::expression::{expression, ExpressionAccess};
 use crate::template::tokenizer::{Token, TokenKind, TokenSlice};
-use crate::{Source, State, quote_spanned};
+use crate::{quote_spanned, Source, State};
 
 pub(crate) type FirstArgument<'a> = Box<ExpressionAccess<'a>>;
 pub(crate) type RemainingArguments<'a> = Vec<(Source<'a>, ExpressionAccess<'a>)>;

--- a/oxiplate-derive/src/template/parser/expression/concat.rs
+++ b/oxiplate-derive/src/template/parser/expression/concat.rs
@@ -1,8 +1,8 @@
 use quote::{quote, quote_spanned};
 
 use super::Res;
-use crate::parser::{Parser as _, context, cut, fail, many1, take};
-use crate::template::parser::expression::{Expression, ExpressionAccess, expression};
+use crate::parser::{context, cut, fail, many1, take, Parser as _};
+use crate::template::parser::expression::{expression, Expression, ExpressionAccess};
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source, State};
 

--- a/oxiplate-derive/src/template/parser/expression/group.rs
+++ b/oxiplate-derive/src/template/parser/expression/group.rs
@@ -1,9 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::quote_spanned;
 
-use crate::parser::{Parser as _, context, take};
+use crate::parser::{context, take, Parser as _};
+use crate::template::parser::expression::{expression, Expression, ExpressionAccess};
 use crate::template::parser::Res;
-use crate::template::parser::expression::{Expression, ExpressionAccess, expression};
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{Source, State};
 

--- a/oxiplate-derive/src/template/parser/expression/ident.rs
+++ b/oxiplate-derive/src/template/parser/expression/ident.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote};
+use quote::{quote, ToTokens, TokenStreamExt};
 
 use super::{Expression, Res};
-use crate::parser::{Parser as _, opt, take};
+use crate::parser::{opt, take, Parser as _};
+use crate::template::parser::expression::arguments::{arguments, ArgumentsGroup};
 use crate::template::parser::Error;
-use crate::template::parser::expression::arguments::{ArgumentsGroup, arguments};
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{Source, State};
 

--- a/oxiplate-derive/src/template/parser/expression/keyword.rs
+++ b/oxiplate-derive/src/template/parser/expression/keyword.rs
@@ -1,12 +1,12 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote_spanned};
+use quote::{quote_spanned, ToTokens, TokenStreamExt};
 
 use super::Res;
-use crate::Source;
 use crate::parser::Parser;
-use crate::template::parser::Error;
 use crate::template::parser::expression::Identifier;
+use crate::template::parser::Error;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
+use crate::Source;
 
 #[derive(Debug)]
 pub(crate) struct Keyword<'a> {

--- a/oxiplate-derive/src/template/parser/expression/literal/bool.rs
+++ b/oxiplate-derive/src/template/parser/expression/literal/bool.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 
-use crate::template::parser::Error;
 use crate::template::parser::expression::{Expression, Res};
+use crate::template::parser::Error;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source};
 

--- a/oxiplate-derive/src/template/parser/expression/literal/char.rs
+++ b/oxiplate-derive/src/template/parser/expression/literal/char.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 
-use crate::template::parser::Error;
 use crate::template::parser::expression::{Expression, Res};
+use crate::template::parser::Error;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source};
 

--- a/oxiplate-derive/src/template/parser/expression/literal/number.rs
+++ b/oxiplate-derive/src/template/parser/expression/literal/number.rs
@@ -1,6 +1,6 @@
 use quote::quote;
 
-use crate::parser::{Parser as _, alt, into, take};
+use crate::parser::{alt, into, take, Parser as _};
 use crate::template::parser::expression::{Expression, Res};
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source};

--- a/oxiplate-derive/src/template/parser/expression/literal/string.rs
+++ b/oxiplate-derive/src/template/parser/expression/literal/string.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 
-use crate::template::parser::Error;
 use crate::template::parser::expression::{Expression, Res};
+use crate::template::parser::Error;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source};
 

--- a/oxiplate-derive/src/template/parser/expression/mod.rs
+++ b/oxiplate-derive/src/template/parser/expression/mod.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
 use syn::token::Dot;
 
 mod arguments;
@@ -15,14 +15,14 @@ mod tuple;
 use self::arguments::arguments;
 use self::concat::Concat;
 use self::ident::IdentifierOrFunction;
-pub(super) use self::ident::{Identifier, identifier};
+pub(super) use self::ident::{identifier, Identifier};
 pub(super) use self::keyword::{Keyword, KeywordParser};
 pub(super) use self::literal::{Bool, Char, Float, Integer, Number, String};
-use super::Res;
 use super::expression::arguments::ArgumentsGroup;
-use super::expression::operator::{Operator, parse_operator};
-use super::expression::prefix_operator::{PrefixOperator, parse_prefixed_expression};
-use crate::parser::{Parser as _, alt, context, cut, fail, into, many0, many1, opt, take};
+use super::expression::operator::{parse_operator, Operator};
+use super::expression::prefix_operator::{parse_prefixed_expression, PrefixOperator};
+use super::Res;
+use crate::parser::{alt, context, cut, fail, into, many0, many1, opt, take, Parser as _};
 use crate::template::parser::expression::group::Group;
 use crate::template::parser::expression::tuple::Tuple;
 use crate::template::tokenizer::{Token, TokenKind, TokenSlice};

--- a/oxiplate-derive/src/template/parser/expression/operator.rs
+++ b/oxiplate-derive/src/template/parser/expression/operator.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote_spanned};
+use quote::{quote_spanned, ToTokens, TokenStreamExt};
 
 use super::super::Res;
-use crate::parser::{Parser as _, alt, take};
+use crate::parser::{alt, take, Parser as _};
 use crate::template::tokenizer::{TokenKind, TokenSlice};
-use crate::{Source, internal_error};
+use crate::{internal_error, Source};
 
 pub(super) fn parse_operator(tokens: TokenSlice) -> Res<Operator> {
     let (tokens, token) = alt((

--- a/oxiplate-derive/src/template/parser/expression/prefix_operator.rs
+++ b/oxiplate-derive/src/template/parser/expression/prefix_operator.rs
@@ -1,11 +1,11 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote_spanned};
+use quote::{quote_spanned, ToTokens, TokenStreamExt};
 
 use super::super::Res;
-use crate::parser::{Parser as _, alt, cut, take};
-use crate::template::parser::expression::{Expression, expression};
+use crate::parser::{alt, cut, take, Parser as _};
+use crate::template::parser::expression::{expression, Expression};
 use crate::template::tokenizer::{TokenKind, TokenSlice};
-use crate::{Source, internal_error};
+use crate::{internal_error, Source};
 
 fn parse_prefix_operator(tokens: TokenSlice) -> Res<PrefixOperator> {
     let (tokens, token) = alt((

--- a/oxiplate-derive/src/template/parser/expression/tuple.rs
+++ b/oxiplate-derive/src/template/parser/expression/tuple.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 
-use super::{Expression, Res, expression};
-use crate::parser::{Parser as _, context, many1, opt, take};
+use super::{expression, Expression, Res};
+use crate::parser::{context, many1, opt, take, Parser as _};
 use crate::template::parser::expression::ExpressionAccess;
 use crate::template::tokenizer::{Token, TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source, State};

--- a/oxiplate-derive/src/template/parser/item.rs
+++ b/oxiplate-derive/src/template/parser/item.rs
@@ -4,13 +4,13 @@ use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 
 use super::comment::comment;
-use super::statement::statement;
 use super::r#static::StaticType;
+use super::statement::statement;
 use super::writ::writ;
 use super::{Statement, Static, Writ};
-use crate::parser::{Error, Parser as _, cut, opt, take};
-use crate::template::parser::Res;
+use crate::parser::{cut, opt, take, Error, Parser as _};
 use crate::template::parser::statement::StatementKind;
+use crate::template::parser::Res;
 use crate::template::tokenizer::{TagKind, TokenKind, TokenSlice, WhitespacePreference};
 use crate::{Source, State};
 

--- a/oxiplate-derive/src/template/parser/item.rs
+++ b/oxiplate-derive/src/template/parser/item.rs
@@ -174,10 +174,12 @@ pub(crate) fn tag_start(tokens: TokenSlice) -> Res<(Option<Item>, TagOpen, Sourc
 
     let (whitespace, removed_whitespace) = match open.whitespace_preference {
         WhitespacePreference::Replace => {
-            if leading_whitespace
-                .as_ref()
-                .is_none_or(|whitespace| whitespace.source().as_str().is_empty())
-            {
+            let has_whitespace = if let Some(whitespace) = leading_whitespace.as_ref() {
+                !whitespace.source().as_str().is_empty()
+            } else {
+                false
+            };
+            if !has_whitespace {
                 let source = open.source().clone();
                 let consumed_source = source.with_collapsed_to_start_full();
                 let error_source = source.clone();

--- a/oxiplate-derive/src/template/parser/mod.rs
+++ b/oxiplate-derive/src/template/parser/mod.rs
@@ -7,15 +7,15 @@ mod template;
 mod writ;
 
 use item::Item;
-use statement::Statement;
 use r#static::Static;
+use statement::Statement;
 pub(crate) use template::parse;
 use writ::Writ;
 
-use crate::Source;
 use crate::parser::Error;
 use crate::template::parser::template::Template;
 use crate::template::tokenizer::TokenKind;
+use crate::Source;
 
 type Res<'a, S> = crate::parser::Res<'a, TokenKind, S>;
 

--- a/oxiplate-derive/src/template/parser/statement/block.rs
+++ b/oxiplate-derive/src/template/parser/statement/block.rs
@@ -1,18 +1,18 @@
 use std::collections::{HashMap, VecDeque};
 
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote};
+use quote::{quote, TokenStreamExt};
 #[cfg(feature = "better-internal-errors")]
 use syn::spanned::Spanned;
 
 use super::super::expression::Identifier;
 use super::super::{Item, Res};
 use super::{Statement, StatementKind};
-use crate::parser::{Parser as _, cut};
+use crate::parser::{cut, Parser as _};
 use crate::template::parser::expression::KeywordParser;
 use crate::template::parser::template::Template;
 use crate::template::tokenizer::TokenSlice;
-use crate::{BuiltTokens, State, internal_error};
+use crate::{internal_error, BuiltTokens, State};
 
 #[derive(Debug)]
 pub struct Block<'a> {

--- a/oxiplate-derive/src/template/parser/statement/escaper.rs
+++ b/oxiplate-derive/src/template/parser/statement/escaper.rs
@@ -1,15 +1,15 @@
 use proc_macro2::TokenStream;
 use quote::quote_spanned;
-use syn::LitStr;
 use syn::spanned::Spanned as _;
+use syn::LitStr;
 
 use super::super::expression::Identifier;
 use super::{Statement, StatementKind};
-use crate::parser::{Parser as _, alt, cut};
-use crate::template::parser::Res;
+use crate::parser::{alt, cut, Parser as _};
 use crate::template::parser::expression::{Keyword, KeywordParser};
+use crate::template::parser::Res;
 use crate::template::tokenizer::TokenSlice;
-use crate::{BuiltTokens, Source, State, internal_error};
+use crate::{internal_error, BuiltTokens, Source, State};
 
 #[derive(Debug)]
 pub struct DefaultEscaper<'a> {

--- a/oxiplate-derive/src/template/parser/statement/extends.rs
+++ b/oxiplate-derive/src/template/parser/statement/extends.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote, quote_spanned};
+use quote::{quote, quote_spanned, TokenStreamExt};
 use syn::LitStr;
 
 use super::{Statement, StatementKind, StaticType};
-use crate::parser::{Parser as _, cut};
+use crate::parser::{cut, Parser as _};
 use crate::template::parser::expression::{KeywordParser, String};
 use crate::template::parser::template::Template;
 use crate::template::parser::{Item, Res};

--- a/oxiplate-derive/src/template/parser/statement/for.rs
+++ b/oxiplate-derive/src/template/parser/statement/for.rs
@@ -1,18 +1,18 @@
 use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote, quote_spanned};
+use quote::{quote, quote_spanned, TokenStreamExt};
 
+use super::super::expression::{expression, Keyword};
 use super::super::Item;
-use super::super::expression::{Keyword, expression};
 use super::{State, Statement, StatementKind};
-use crate::parser::{Parser as _, cut, into};
-use crate::template::parser::Res;
+use crate::parser::{cut, into, Parser as _};
 use crate::template::parser::expression::{ExpressionAccess, KeywordParser};
 use crate::template::parser::statement::helpers::pattern::Pattern;
 use crate::template::parser::template::Template;
+use crate::template::parser::Res;
 use crate::template::tokenizer::TokenSlice;
-use crate::{BuiltTokens, Source, internal_error};
+use crate::{internal_error, BuiltTokens, Source};
 
 #[derive(Debug)]
 pub struct For<'a> {

--- a/oxiplate-derive/src/template/parser/statement/helpers/pattern/literal.rs
+++ b/oxiplate-derive/src/template/parser/statement/helpers/pattern/literal.rs
@@ -1,11 +1,11 @@
 use proc_macro2::TokenStream;
 
-use crate::Source;
-use crate::parser::{Parser as _, alt, into};
-use crate::template::parser::Res;
+use crate::parser::{alt, into, Parser as _};
 use crate::template::parser::expression::{Bool, Char, Float, Integer, Number, String};
 use crate::template::parser::statement::helpers::pattern::Pattern;
+use crate::template::parser::Res;
 use crate::template::tokenizer::TokenSlice;
+use crate::Source;
 
 /// A literal value to match against.
 /// See: <https://doc.rust-lang.org/book/ch19-03-pattern-syntax.html#matching-literals>

--- a/oxiplate-derive/src/template/parser/statement/helpers/pattern/mod.rs
+++ b/oxiplate-derive/src/template/parser/statement/helpers/pattern/mod.rs
@@ -6,15 +6,15 @@ mod tuple;
 use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
 
 use self::literal::Literal;
-use self::range::Range;
 use self::r#struct::Struct;
+use self::range::Range;
 use self::tuple::Tuple;
-use crate::parser::{Parser as _, alt, cut, into, many1, opt, take};
-use crate::template::parser::Res;
+use crate::parser::{alt, cut, into, many1, opt, take, Parser as _};
 use crate::template::parser::expression::Identifier;
+use crate::template::parser::Res;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{Source, State};
 

--- a/oxiplate-derive/src/template/parser/statement/helpers/pattern/range.rs
+++ b/oxiplate-derive/src/template/parser/statement/helpers/pattern/range.rs
@@ -2,9 +2,9 @@ use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 
 use super::Pattern;
-use crate::parser::{Parser as _, alt, into, opt, take};
-use crate::template::parser::Res;
+use crate::parser::{alt, into, opt, take, Parser as _};
 use crate::template::parser::expression::{Char, Float, Integer, Number};
+use crate::template::parser::Res;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{Source, State};
 

--- a/oxiplate-derive/src/template/parser/statement/helpers/pattern/struct.rs
+++ b/oxiplate-derive/src/template/parser/statement/helpers/pattern/struct.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote, quote_spanned};
+use quote::{quote, quote_spanned, TokenStreamExt};
 
 use super::Pattern;
-use crate::parser::{Parser as _, alt, context, cut, into, many0, take};
-use crate::template::parser::Res;
+use crate::parser::{alt, context, cut, into, many0, take, Parser as _};
 use crate::template::parser::expression::Identifier;
 use crate::template::parser::statement::helpers::pattern::Path;
+use crate::template::parser::Res;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source, State};
 

--- a/oxiplate-derive/src/template/parser/statement/helpers/pattern/tuple.rs
+++ b/oxiplate-derive/src/template/parser/statement/helpers/pattern/tuple.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote_spanned};
+use quote::{quote_spanned, TokenStreamExt};
 
 use super::Pattern;
-use crate::parser::{Parser as _, cut, many1, opt, take};
+use crate::parser::{cut, many1, opt, take, Parser as _};
 use crate::template::parser::Res;
 use crate::template::tokenizer::{Token, TokenKind, TokenSlice};
 use crate::{Source, State};

--- a/oxiplate-derive/src/template/parser/statement/if.rs
+++ b/oxiplate-derive/src/template/parser/statement/if.rs
@@ -1,15 +1,15 @@
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote};
+use quote::{quote, TokenStreamExt};
 
 use super::super::expression::expression;
 use super::super::{Item, Res};
 use super::{Statement, StatementKind};
-use crate::parser::{Parser as _, cut, opt, take};
+use crate::parser::{cut, opt, take, Parser as _};
 use crate::template::parser::expression::{ExpressionAccess, KeywordParser};
 use crate::template::parser::statement::helpers::pattern::Pattern;
 use crate::template::parser::template::Template;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
-use crate::{BuiltTokens, Source, State, internal_error};
+use crate::{internal_error, BuiltTokens, Source, State};
 
 #[derive(Debug)]
 pub(crate) enum IfType<'a> {
@@ -89,7 +89,7 @@ impl<'a> If<'a> {
                 if let Some(template) = &mut self.otherwise {
                     template.0.push(item);
                 } else {
-                    self.ifs.last_mut().unwrap().1.0.push(item);
+                    self.ifs.last_mut().unwrap().1 .0.push(item);
                 }
             }
         }

--- a/oxiplate-derive/src/template/parser/statement/include.rs
+++ b/oxiplate-derive/src/template/parser/statement/include.rs
@@ -1,15 +1,15 @@
 use std::collections::{HashMap, VecDeque};
 
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote, quote_spanned};
+use quote::{quote, quote_spanned, TokenStreamExt};
 use syn::LitStr;
 
 use super::{Statement, StatementKind};
-use crate::parser::{Parser as _, cut};
-use crate::template::parser::Res;
+use crate::parser::{cut, Parser as _};
 use crate::template::parser::expression::{KeywordParser, String};
+use crate::template::parser::Res;
 use crate::template::tokenizer::TokenSlice;
-use crate::{BuiltTokens, oxiplate_internal};
+use crate::{oxiplate_internal, BuiltTokens};
 
 #[derive(Debug)]
 pub struct Include<'a> {

--- a/oxiplate-derive/src/template/parser/statement/let.rs
+++ b/oxiplate-derive/src/template/parser/statement/let.rs
@@ -1,10 +1,10 @@
 use quote::quote_spanned;
 
-use super::super::expression::{Identifier, Keyword, expression};
+use super::super::expression::{expression, Identifier, Keyword};
 use super::{State, Statement, StatementKind};
-use crate::parser::{Parser as _, cut, take};
-use crate::template::parser::Res;
+use crate::parser::{cut, take, Parser as _};
 use crate::template::parser::expression::{ExpressionAccess, KeywordParser};
+use crate::template::parser::Res;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source};
 

--- a/oxiplate-derive/src/template/parser/statement/match.rs
+++ b/oxiplate-derive/src/template/parser/statement/match.rs
@@ -1,18 +1,18 @@
 use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote, quote_spanned};
+use quote::{quote, quote_spanned, TokenStreamExt};
 
 use super::super::Item;
 use super::{Statement, StatementKind};
-use crate::parser::{Parser as _, cut, many0, opt, take};
-use crate::template::parser::Res;
-use crate::template::parser::expression::{ExpressionAccess, KeywordParser, expression};
-use crate::template::parser::statement::helpers::pattern::Pattern;
+use crate::parser::{cut, many0, opt, take, Parser as _};
+use crate::template::parser::expression::{expression, ExpressionAccess, KeywordParser};
 use crate::template::parser::r#static::StaticType;
+use crate::template::parser::statement::helpers::pattern::Pattern;
 use crate::template::parser::template::Template;
+use crate::template::parser::Res;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
-use crate::{BuiltTokens, Source, State, internal_error};
+use crate::{internal_error, BuiltTokens, Source, State};
 
 #[derive(Debug)]
 pub(crate) struct Match<'a> {

--- a/oxiplate-derive/src/template/parser/statement/mod.rs
+++ b/oxiplate-derive/src/template/parser/statement/mod.rs
@@ -13,11 +13,11 @@ use quote::quote_spanned;
 pub(crate) use self::escaper::DefaultEscaper;
 use super::r#static::StaticType;
 use super::{Item, Res};
-use crate::parser::{Parser as _, alt, cut, into};
-use crate::template::parser::Error;
+use crate::parser::{alt, cut, into, Parser as _};
 use crate::template::parser::item::tag_end;
 use crate::template::parser::statement::r#let::Let;
 use crate::template::parser::template::parse_item;
+use crate::template::parser::Error;
 use crate::template::tokenizer::{TagKind, TokenSlice};
 use crate::{BuiltTokens, Source, State};
 

--- a/oxiplate-derive/src/template/parser/static.rs
+++ b/oxiplate-derive/src/template/parser/static.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::Item;
-use crate::parser::{Parser as _, alt, take};
+use crate::parser::{alt, take, Parser as _};
 use crate::template::parser::Res;
 use crate::template::tokenizer::{TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source};

--- a/oxiplate-derive/src/template/parser/template.rs
+++ b/oxiplate-derive/src/template/parser/template.rs
@@ -1,16 +1,16 @@
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote};
+use quote::{quote, TokenStreamExt};
 
-use super::item::{ItemToken, parse_tag};
+use super::item::{parse_tag, ItemToken};
 use super::r#static::parse_static;
 use super::{Item, Static};
+use crate::parser::{alt, opt, parse_all, take, Parser as _};
+use crate::template::parser::item::parse_trailing_whitespace;
+use crate::template::parser::Res;
+use crate::template::tokenizer::{TokenKind, TokenSlice, WhitespacePreference};
 #[cfg(coverage_nightly)]
 use crate::Source;
-use crate::parser::{Parser as _, alt, opt, parse_all, take};
-use crate::template::parser::Res;
-use crate::template::parser::item::parse_trailing_whitespace;
-use crate::template::tokenizer::{TokenKind, TokenSlice, WhitespacePreference};
-use crate::{BuiltTokens, State, internal_error};
+use crate::{internal_error, BuiltTokens, State};
 
 /// Collection of items in the template and estimated output length.
 #[derive(Debug)]

--- a/oxiplate-derive/src/template/parser/writ.rs
+++ b/oxiplate-derive/src/template/parser/writ.rs
@@ -193,12 +193,12 @@ impl<'a> Writ<'a> {
             );
         }
 
-        let default_group: &(String, EscaperGroup) = if let Some(default_group) =
+        let default_group: Cow<(String, EscaperGroup)> = if let Some(default_group) =
             &state.default_escaper_group
         {
-            default_group
+            Cow::Borrowed(default_group)
         } else if let Some(inferred_group) = &state.inferred_escaper_group {
-            inferred_group
+            Cow::Borrowed(inferred_group)
         } else if let Some(fallback_group_name) = &state.config.fallback_escaper_group {
             if fallback_group_name == "raw" {
                 #[cfg(not(feature = "oxiplate"))]
@@ -226,7 +226,7 @@ impl<'a> Writ<'a> {
                 );
             };
 
-            &(fallback_group_name.clone(), fallback_group.clone())
+            Cow::Owned((fallback_group_name.clone(), fallback_group.clone()))
         } else {
             #[cfg(not(feature = "config"))]
             return token_error!(

--- a/oxiplate-derive/src/template/parser/writ.rs
+++ b/oxiplate-derive/src/template/parser/writ.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Debug;
 
 use proc_macro2::{Span, TokenStream};
@@ -6,11 +7,11 @@ use syn::spanned::Spanned;
 use syn::token::PathSep;
 use syn::{Path, PathSegment};
 
-use super::Item;
-use super::expression::{ExpressionAccess, Identifier, expression};
+use super::expression::{expression, ExpressionAccess, Identifier};
 use super::item::tag_end;
+use super::Item;
 use crate::config::EscaperGroup;
-use crate::parser::{Parser as _, cut, opt, take};
+use crate::parser::{cut, opt, take, Parser as _};
 use crate::template::parser::Res;
 use crate::template::tokenizer::{TagKind, TokenKind, TokenSlice};
 use crate::{BuiltTokens, Source, State};

--- a/oxiplate-derive/src/template/tokenizer/comment.rs
+++ b/oxiplate-derive/src/template/tokenizer/comment.rs
@@ -1,6 +1,6 @@
 use super::Token;
-use crate::template::tokenizer::Res;
 use crate::template::tokenizer::kind::TokenKind;
+use crate::template::tokenizer::Res;
 use crate::tokenizer::BufferedSource;
 
 pub fn consume_comment<'a>(source: &mut BufferedSource<'a>) -> Res<'a> {

--- a/oxiplate-derive/src/template/tokenizer/expression/char.rs
+++ b/oxiplate-derive/src/template/tokenizer/expression/char.rs
@@ -1,8 +1,8 @@
 use super::Token;
-use crate::Source;
-use crate::template::tokenizer::Res;
 use crate::template::tokenizer::kind::TokenKind;
+use crate::template::tokenizer::Res;
 use crate::tokenizer::{BufferedSource, ParseError, UnexpectedTokenError};
+use crate::Source;
 
 /// Parse char literal (e.g., `'a'`).
 /// See: <https://doc.rust-lang.org/reference/tokens.html#character-literals>

--- a/oxiplate-derive/src/template/tokenizer/expression/mod.rs
+++ b/oxiplate-derive/src/template/tokenizer/expression/mod.rs
@@ -3,15 +3,15 @@ mod number;
 mod string;
 
 use super::Token;
-use crate::Source;
 use crate::template::tokenizer::expression::char::consume_char;
 use crate::template::tokenizer::expression::number::{consume_alternative_base, consume_decimal};
 use crate::template::tokenizer::expression::string::{consume_raw_string, consume_string};
 use crate::template::tokenizer::{
-    Context, Res, TagKind, TokenKind, WhitespacePreference, consume_possible_tag_end,
-    consume_possible_tag_end_whitespace_adjustment, whitespace,
+    consume_possible_tag_end, consume_possible_tag_end_whitespace_adjustment, whitespace, Context,
+    Res, TagKind, TokenKind, WhitespacePreference,
 };
 use crate::tokenizer::{BufferedSource, UnexpectedTokenError};
+use crate::Source;
 
 #[allow(clippy::too_many_lines)]
 pub fn consume_expression_token<'a>(

--- a/oxiplate-derive/src/template/tokenizer/expression/number.rs
+++ b/oxiplate-derive/src/template/tokenizer/expression/number.rs
@@ -1,7 +1,7 @@
 use super::Token;
-use crate::Source;
 use crate::template::tokenizer::{Res, TokenKind};
 use crate::tokenizer::{BufferedSource, ParseError, UnexpectedTokenError};
+use crate::Source;
 
 /// Parse decimal and floating-point literals.
 /// See: <https://doc.rust-lang.org/reference/tokens.html#integer-literals>

--- a/oxiplate-derive/src/template/tokenizer/expression/string.rs
+++ b/oxiplate-derive/src/template/tokenizer/expression/string.rs
@@ -1,7 +1,7 @@
 use super::Token;
-use crate::Source;
 use crate::template::tokenizer::{Res, TokenKind};
 use crate::tokenizer::{BufferedSource, ParseError, UnexpectedTokenError};
+use crate::Source;
 
 fn parse_string(source: &mut BufferedSource) -> Result<String, ParseError> {
     let mut string = String::new();

--- a/oxiplate-derive/src/template/tokenizer/mod.rs
+++ b/oxiplate-derive/src/template/tokenizer/mod.rs
@@ -5,7 +5,6 @@ mod r#static;
 
 use self::expression::consume_ident;
 pub use self::kind::{TagKind, TokenKind, WhitespacePreference};
-use crate::Source;
 use crate::template::tokenizer::comment::consume_comment;
 use crate::template::tokenizer::expression::consume_expression_token;
 use crate::template::tokenizer::r#static::{
@@ -13,6 +12,7 @@ use crate::template::tokenizer::r#static::{
 };
 pub use crate::tokenizer::Eof;
 use crate::tokenizer::{BufferedSource, UnexpectedTokenError};
+use crate::Source;
 
 pub type Token<'a> = crate::tokenizer::Token<'a, TokenKind>;
 pub type TokenSlice<'a> = crate::tokenizer::TokenSlice<'a, TokenKind>;

--- a/oxiplate-derive/src/template/tokenizer/static.rs
+++ b/oxiplate-derive/src/template/tokenizer/static.rs
@@ -1,5 +1,5 @@
 use crate::template::tokenizer::kind::WhitespacePreference;
-use crate::template::tokenizer::{Context, Res, TagKind, TokenKind, whitespace};
+use crate::template::tokenizer::{whitespace, Context, Res, TagKind, TokenKind};
 use crate::tokenizer::{BufferedSource, Token};
 
 pub fn consume_static_whitespace<'a>(source: &mut BufferedSource<'a>) -> Res<'a> {

--- a/oxiplate-derive/src/tokenizer/mod.rs
+++ b/oxiplate-derive/src/tokenizer/mod.rs
@@ -7,8 +7,8 @@ use std::fmt::Debug;
 pub use self::buffered_source::BufferedSource;
 pub use self::slice::TokenSlice;
 pub use self::token::Token;
-use crate::Source;
 pub use crate::tokenizer::token::ParseError;
+use crate::Source;
 
 pub(super) type Tokens<'a, K> = &'a [Result<Token<'a, K>, UnexpectedTokenError<'a>>];
 

--- a/oxiplate-derive/tests/clippy/Cargo.toml
+++ b/oxiplate-derive/tests/clippy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy-tests"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 oxiplate-derive = { path = "../../" }

--- a/oxiplate-derive/tests/config/crates/.template/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/.template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-template"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/.template/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/.template/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-template"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/array-of-tables/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/array-of-tables/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-array-of-tables"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/array-of-tables/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/array-of-tables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-array-of-tables"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/array/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-array"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/array/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/array/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-array"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/bad-hex/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/bad-hex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-bad-hex"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/bad-hex/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/bad-hex/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-bad-hex"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/double-assign/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/double-assign/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-double-assign"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/double-assign/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/double-assign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-double-assign"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/double-table/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/double-table/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-double-table"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/double-table/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/double-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-double-table"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/eof-in-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/eof-in-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-eof-in-string"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/eof-in-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/eof-in-string/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-eof-in-string"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/escaper-bool/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-bool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-escaper-bool"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/escaper-bool/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-bool/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-escaper-bool"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/escaper-group-non-ident/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-group-non-ident/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-escaper-group-non-ident"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/escaper-group-non-ident/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-group-non-ident/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-escaper-group-non-ident"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/escaper-group-non-path/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-group-non-path/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-escaper-group-non-path"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/escaper-group-non-path/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-group-non-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-escaper-group-non-path"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/escaper-group-relative/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-group-relative/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-escaper-group-relative"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/escaper-group-relative/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-group-relative/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-escaper-group-relative"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/escaper-group-value/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-group-value/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-escaper-group-value"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/escaper-group-value/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-group-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-escaper-group-value"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/escaper-table/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-table/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-escaper-table"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/escaper-table/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/escaper-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-escaper-table"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/fallback-escaper-group-bool/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/fallback-escaper-group-bool/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-fallback-escaper-group-bool"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/fallback-escaper-group-bool/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/fallback-escaper-group-bool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-fallback-escaper-group-bool"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/infer-escaper-group-from-file-extension-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/infer-escaper-group-from-file-extension-string/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-infer-escaper-group-from-file-extension-string"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/infer-escaper-group-from-file-extension-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/infer-escaper-group-from-file-extension-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-infer-escaper-group-from-file-extension-string"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/missing-value/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/missing-value/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-missing-value"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/missing-value/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/missing-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-missing-value"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/newline-in-string-unclosed-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/newline-in-string-unclosed-string/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-newline-in-string-unclosed-string"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/newline-in-string-unclosed-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/newline-in-string-unclosed-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-newline-in-string-unclosed-string"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/newline-in-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/newline-in-string/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-newline-in-string"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/newline-in-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/newline-in-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-newline-in-string"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/newline-instead-of-value/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/newline-instead-of-value/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-newline-instead-of-value"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/newline-instead-of-value/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/newline-instead-of-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-newline-instead-of-value"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/number-escaper/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/number-escaper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-number-escaper"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/number-escaper/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/number-escaper/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-number-escaper"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/optimized-renderer-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/optimized-renderer-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-optimized-renderer-string"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/optimized-renderer-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/optimized-renderer-string/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-optimized-renderer-string"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/overwriting-value-with-table-via-ancestor/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/overwriting-value-with-table-via-ancestor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-overwriting-value-with-table-via-ancestor"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/overwriting-value-with-table-via-ancestor/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/overwriting-value-with-table-via-ancestor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-overwriting-value-with-table-via-ancestor"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/overwriting-value-with-table/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/overwriting-value-with-table/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-overwriting-value-with-table"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/overwriting-value-with-table/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/overwriting-value-with-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-overwriting-value-with-table"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/require-specifying-escaper-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/require-specifying-escaper-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-require-specifying-escaper-string"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/require-specifying-escaper-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/require-specifying-escaper-string/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-require-specifying-escaper-string"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/unexpected-escape-sequence-unclosed-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unexpected-escape-sequence-unclosed-string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-unexpected-escape-sequence-unclosed-string"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/unexpected-escape-sequence-unclosed-string/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unexpected-escape-sequence-unclosed-string/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-unexpected-escape-sequence-unclosed-string"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/unexpected-escape-sequence/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unexpected-escape-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-unexpected-escape-sequence"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/unexpected-escape-sequence/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unexpected-escape-sequence/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-unexpected-escape-sequence"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/unmatched-bracket/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unmatched-bracket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-unmatched-bracket"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/unmatched-bracket/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unmatched-bracket/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-unmatched-bracket"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/unrecognized-key/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unrecognized-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-unrecognized-key"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/unrecognized-key/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unrecognized-key/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-unrecognized-key"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/unsupported-brace/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unsupported-brace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-unsupported-brace"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/unsupported-brace/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/unsupported-brace/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-unsupported-brace"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/config/crates/value-after-table-declaration/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/value-after-table-declaration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config-value-after-table-declaration"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/config/crates/value-after-table-declaration/Cargo.toml
+++ b/oxiplate-derive/tests/config/crates/value-after-table-declaration/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config-value-after-table-declaration"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/crates/config/Cargo.toml
+++ b/oxiplate-derive/tests/crates/config/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-config"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.101"

--- a/oxiplate-derive/tests/crates/config/Cargo.toml
+++ b/oxiplate-derive/tests/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-config"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/crates/optimized-renderer/Cargo.toml
+++ b/oxiplate-derive/tests/crates/optimized-renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-optimized-renderer"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/crates/optimized-renderer/Cargo.toml
+++ b/oxiplate-derive/tests/crates/optimized-renderer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-optimized-renderer"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate-derive/tests/crates/unreachable-stable/Cargo.toml
+++ b/oxiplate-derive/tests/crates/unreachable-stable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-unreachable-stable"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/crates/unreachable-stable/Cargo.toml
+++ b/oxiplate-derive/tests/crates/unreachable-stable/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-unreachable-stable"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate-derive/tests/crates/unreachable/Cargo.toml
+++ b/oxiplate-derive/tests/crates/unreachable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-derive-test-unreachable"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate-derive/tests/crates/unreachable/Cargo.toml
+++ b/oxiplate-derive/tests/crates/unreachable/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-derive-test-unreachable"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate-traits/Cargo.toml
+++ b/oxiplate-traits/Cargo.toml
@@ -17,7 +17,7 @@ itoa = { version = "1.0.15", optional = true }
 
 [features]
 
-default = ["fast-escape-ints"]
+default = ["fast-escape-ints", "on-unimplemented-cow-string"]
 
 # Feature only meant to be turned on for tests.
 # Changes the output for various types
@@ -27,6 +27,10 @@ debug-fast-escape-type-priority = []
 # Includes the `itoa` dependency
 # and speeds up integer escaping.
 fast-escape-ints = ["dep:itoa"]
+
+# Improved error message for non-stringy-values with the cow prefix.
+# Requires Rust 1.78.0 or higher.
+on-unimplemented-cow-string = []
 
 [lints]
 workspace = true

--- a/oxiplate-traits/src/cow_str.rs
+++ b/oxiplate-traits/src/cow_str.rs
@@ -17,20 +17,23 @@ use crate::{Escaper, FastEscape};
 /// ```oxip
 /// {{ >message | append(>"!") }}
 /// ```
-#[diagnostic::on_unimplemented(
-    message = "{Self} is expected to be prefixed by `>` and implement \
-               `::oxiplate_traits::ToCowString`.",
-    label = "Insert `>` prefix before this expression if `{Self}` is a string-like value (`str`, \
-             `impl Display`, etc).",
-    note = "Consider implementing `::oxiplate_traits::ToCowStr` if `{Self}` is owned by your \
-            crate, and then prefix with `>`.",
-    note = "If `{Self}` is not a string-like value, perhaps you meant to pass a different \
-            argument to the filter?",
-    note = "Oxiplate efficiently builds `::std::borrow::Cow<'a, str>` when a `>` prefix is used \
-            on an expression, and wraps it in `::oxiplate_traits::CowStr<'a>` which is used by \
-            filters for string arguments. Because the syntax for doing so is not obvious and \
-            prone to silently breaking, this alternative syntax is used to let Oxiplate handle \
-            the details while ensuring it's tested properly."
+#[cfg_attr(
+    feature = "on-unimplemented-cow-string",
+    diagnostic::on_unimplemented(
+        message = "{Self} is expected to be prefixed by `>` and implement \
+                   `::oxiplate_traits::ToCowString`.",
+        label = "Insert `>` prefix before this expression if `{Self}` is a string-like value \
+                 (`str`, `impl Display`, etc).",
+        note = "Consider implementing `::oxiplate_traits::ToCowStr` if `{Self}` is owned by your \
+                crate, and then prefix with `>`.",
+        note = "If `{Self}` is not a string-like value, perhaps you meant to pass a different \
+                argument to the filter?",
+        note = "Oxiplate efficiently builds `::std::borrow::Cow<'a, str>` when a `>` prefix is \
+                used on an expression, and wraps it in `::oxiplate_traits::CowStr<'a>` which is \
+                used by filters for string arguments. Because the syntax for doing so is not \
+                obvious and prone to silently breaking, this alternative syntax is used to let \
+                Oxiplate handle the details while ensuring it's tested properly."
+    )
 )]
 pub trait CowStr<'a> {
     /// Extract the contained `Cow<str>`.

--- a/oxiplate-traits/src/lib.rs
+++ b/oxiplate-traits/src/lib.rs
@@ -29,7 +29,7 @@ pub use unescaped_text::{FastEscape, UnescapedText, UnescapedTextWrapper};
 /// use oxiplate_traits::CowStr;
 /// #[cfg(test)]
 /// # compile_error!("tests don't run in docs");
-/// use oxiplate_traits::{ToCowStr, cow_str_wrapper};
+/// use oxiplate_traits::{cow_str_wrapper, ToCowStr};
 ///
 /// pub fn upper<'a, E: CowStr<'a>>(expression: E) -> Cow<'a, str> {
 ///     match expression.cow_str() {

--- a/oxiplate/Cargo.toml
+++ b/oxiplate/Cargo.toml
@@ -24,7 +24,7 @@ rustversion = "1.0.19"
 trybuild = "1.0.115"
 
 [features]
-default = ["built-in-escapers", "config", "fast-escape-ints"]
+default = ["built-in-escapers", "config", "fast-escape-ints", "on-unimplemented-cow-string"]
 
 # Improved error messages requiring nightly.
 # Highly recommended during development.
@@ -55,6 +55,10 @@ external-template-spans = ["oxiplate-derive/external-template-spans"]
 # Includes the `itoa` dependency
 # and speeds up integer escaping.
 fast-escape-ints = ["oxiplate-traits/fast-escape-ints"]
+
+# Improved error message for non-stringy-values with the cow prefix.
+# Requires Rust 1.78.0 or higher.
+on-unimplemented-cow-string = ["oxiplate-traits/on-unimplemented-cow-string"]
 
 # Feature for conditional compilation to cover otherwise unreachable code.
 unreachable = ["oxiplate-derive/unreachable"]

--- a/oxiplate/src/filters/lower.rs
+++ b/oxiplate/src/filters/lower.rs
@@ -8,7 +8,7 @@ use core::fmt::Display;
 
 use oxiplate_traits::CowStr;
 #[cfg(test)]
-use oxiplate_traits::{ToCowStr, cow_str_wrapper};
+use oxiplate_traits::{cow_str_wrapper, ToCowStr};
 
 /// Returns the lowercase version of the string.
 ///

--- a/oxiplate/src/filters/trim.rs
+++ b/oxiplate/src/filters/trim.rs
@@ -8,7 +8,7 @@ use core::fmt::Display;
 
 use oxiplate_traits::CowStr;
 #[cfg(test)]
-use oxiplate_traits::{ToCowStr, cow_str_wrapper};
+use oxiplate_traits::{cow_str_wrapper, ToCowStr};
 
 /// Trims the leading and trailing whitespace from the input.
 ///

--- a/oxiplate/src/filters/upper.rs
+++ b/oxiplate/src/filters/upper.rs
@@ -8,7 +8,7 @@ use core::fmt::Display;
 
 use oxiplate_traits::CowStr;
 #[cfg(test)]
-use oxiplate_traits::{ToCowStr, cow_str_wrapper};
+use oxiplate_traits::{cow_str_wrapper, ToCowStr};
 
 /// Returns the uppercase version of the string.
 ///

--- a/oxiplate/src/lib.rs
+++ b/oxiplate/src/lib.rs
@@ -53,5 +53,5 @@ pub use oxiplate_traits::{
 /// # }
 /// ```
 pub mod prelude {
-    pub use super::{Oxiplate, Render, filters as filters_for_oxiplate};
+    pub use super::{filters as filters_for_oxiplate, Oxiplate, Render};
 }

--- a/oxiplate/tests/crates/config-with-feature-turned-off/Cargo.toml
+++ b/oxiplate/tests/crates/config-with-feature-turned-off/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-config-with-feature-turned-off"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/config-with-feature-turned-off/Cargo.toml
+++ b/oxiplate/tests/crates/config-with-feature-turned-off/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-config-with-feature-turned-off"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/default-html/Cargo.toml
+++ b/oxiplate/tests/crates/default-html/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-default-html"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/default-html/Cargo.toml
+++ b/oxiplate/tests/crates/default-html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-default-html"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/default-json/Cargo.toml
+++ b/oxiplate/tests/crates/default-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-default-json"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/default-json/Cargo.toml
+++ b/oxiplate/tests/crates/default-json/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-default-json"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/default-raw/Cargo.toml
+++ b/oxiplate/tests/crates/default-raw/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-default-raw"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/default-raw/Cargo.toml
+++ b/oxiplate/tests/crates/default-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-default-raw"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/escaper-without-config/Cargo.toml
+++ b/oxiplate/tests/crates/escaper-without-config/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-escaper-without-config"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/escaper-without-config/Cargo.toml
+++ b/oxiplate/tests/crates/escaper-without-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-escaper-without-config"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/escaper-without-default-escaper-group/Cargo.toml
+++ b/oxiplate/tests/crates/escaper-without-default-escaper-group/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-escaper-without-default-escaper-group"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/escaper-without-default-escaper-group/Cargo.toml
+++ b/oxiplate/tests/crates/escaper-without-default-escaper-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-escaper-without-default-escaper-group"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/fallback-group-malformed/Cargo.toml
+++ b/oxiplate/tests/crates/fallback-group-malformed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-fallback-group-malformed"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/fallback-group-malformed/Cargo.toml
+++ b/oxiplate/tests/crates/fallback-group-malformed/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-fallback-group-malformed"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/fast-escape-type-priority/Cargo.toml
+++ b/oxiplate/tests/crates/fast-escape-type-priority/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-fast-escape-type-priority"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/fast-escape-type-priority/Cargo.toml
+++ b/oxiplate/tests/crates/fast-escape-type-priority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-fast-escape-type-priority"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/file-extension-inferrence-off/Cargo.toml
+++ b/oxiplate/tests/crates/file-extension-inferrence-off/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-file-extension-inferrence-off"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/file-extension-inferrence-off/Cargo.toml
+++ b/oxiplate/tests/crates/file-extension-inferrence-off/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-file-extension-inferrence-off"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/require-specifying-escaper/Cargo.toml
+++ b/oxiplate/tests/crates/require-specifying-escaper/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-require-specifying-escaper"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/require-specifying-escaper/Cargo.toml
+++ b/oxiplate/tests/crates/require-specifying-escaper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-require-specifying-escaper"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/slow-escape-ints/Cargo.toml
+++ b/oxiplate/tests/crates/slow-escape-ints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-slow-escape-ints"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/slow-escape-ints/Cargo.toml
+++ b/oxiplate/tests/crates/slow-escape-ints/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-slow-escape-ints"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/template-dir-absolute/Cargo.toml
+++ b/oxiplate/tests/crates/template-dir-absolute/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-template-dir-absolute"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/template-dir-absolute/Cargo.toml
+++ b/oxiplate/tests/crates/template-dir-absolute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-template-dir-absolute"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/template-dir-file/Cargo.toml
+++ b/oxiplate/tests/crates/template-dir-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-template-dir-file"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/template-dir-file/Cargo.toml
+++ b/oxiplate/tests/crates/template-dir-file/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-template-dir-file"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/template-dir-missing/Cargo.toml
+++ b/oxiplate/tests/crates/template-dir-missing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-template-dir-missing"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/template-dir-missing/Cargo.toml
+++ b/oxiplate/tests/crates/template-dir-missing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-template-dir-missing"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/template-dir-symlink/Cargo.toml
+++ b/oxiplate/tests/crates/template-dir-symlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-template-dir-symlink"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/template-dir-symlink/Cargo.toml
+++ b/oxiplate/tests/crates/template-dir-symlink/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-template-dir-symlink"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/unreachable-stable/Cargo.toml
+++ b/oxiplate/tests/crates/unreachable-stable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-unreachable-stable"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/oxiplate/tests/crates/unreachable-stable/Cargo.toml
+++ b/oxiplate/tests/crates/unreachable-stable/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-unreachable-stable"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/unreachable/Cargo.toml
+++ b/oxiplate/tests/crates/unreachable/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxiplate-test-unreachable"
 edition = "2021"
 publish = false
+version = "0.1.0"
 
 [dev-dependencies]
 trybuild = "1.0.115"

--- a/oxiplate/tests/crates/unreachable/Cargo.toml
+++ b/oxiplate/tests/crates/unreachable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxiplate-test-unreachable"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dev-dependencies]


### PR DESCRIPTION
[Cargo usage stats](https://p.datadoghq.com/sb/3a172e20-e9e1-11ed-80e3-da7ad0900002-973f4c1011257befa8598303217bfe3a?fromUser=false&refresh_mode=sliding&from_ts=1767926693591&to_ts=1770605093591&live=true) suggest 1.75.0 is pretty heavily used (~10%), but most other requests are 1.85.0+.

1.85.1 = ~83%
1.82.0 = ~87%
1.79.0 = ~88%
1.78.0 = ~88%
1.75.0 = ~98% (`async fn`, `-> impl Trait`)
1.74.1 = ~98%

<img width="778" height="430" alt="image" src="https://github.com/user-attachments/assets/6361f99d-c6b7-46cb-a6a2-52ae43a258f6" />

Should probably try to support 1.75.0 because such a large portion of users are pinned to that version.