### PR TITLE
feat!: switched `filters_for_oxiplate` to be relative to the current module

### DIFF
--- a/oxiplate-derive/src/template/parser/expression/mod.rs
+++ b/oxiplate-derive/src/template/parser/expression/mod.rs
@@ -257,7 +257,7 @@ impl<'a> Expression<'a> {
                         ::oxiplate::CowStrWrapper::new(
                             (
                                 &&::oxiplate::ToCowStrWrapper::new(
-                                    &(crate::filters_for_oxiplate::#name #arguments)
+                                    &(filters_for_oxiplate::#name #arguments)
                                 )
                             ).to_cow_str()
                         )
@@ -275,7 +275,7 @@ impl<'a> Expression<'a> {
         } else {
             (
                 quote_spanned! {span=>
-                    crate::filters_for_oxiplate::#name #arguments
+                    filters_for_oxiplate::#name #arguments
                 },
                 estimated_length,
             )

--- a/oxiplate-derive/tests/expansion/expected/filters.rs
+++ b/oxiplate-derive/tests/expansion/expected/filters.rs
@@ -63,20 +63,14 @@ impl ::core::fmt::Display for Respond {
             oxiplate_formatter
                 .write_str(
                     &alloc::string::ToString::to_string(
-                        &(crate::filters_for_oxiplate::respond(
-                            self.message,
-                            *self.respond,
-                        )),
+                        &(filters_for_oxiplate::respond(self.message, *self.respond)),
                     ),
                 )?;
             oxiplate_formatter.write_str(" ")?;
             oxiplate_formatter
                 .write_str(
                     &alloc::string::ToString::to_string(
-                        &(crate::filters_for_oxiplate::respond(
-                            self.message,
-                            !*self.respond,
-                        )),
+                        &(filters_for_oxiplate::respond(self.message, !*self.respond)),
                     ),
                 )?;
             string
@@ -181,10 +175,7 @@ impl ::core::fmt::Display for Shorten {
             oxiplate_formatter
                 .write_str(
                     &alloc::string::ToString::to_string(
-                        &(crate::filters_for_oxiplate::shorten(
-                            self.message,
-                            self.max_length,
-                        )),
+                        &(filters_for_oxiplate::shorten(self.message, self.max_length)),
                     ),
                 )?;
             string
@@ -289,7 +280,7 @@ impl ::core::fmt::Display for Pad {
             oxiplate_formatter
                 .write_str(
                     &alloc::string::ToString::to_string(
-                        &(crate::filters_for_oxiplate::pad(self.number, self.length)),
+                        &(filters_for_oxiplate::pad(self.number, self.length)),
                     ),
                 )?;
             string
@@ -378,8 +369,8 @@ impl ::core::fmt::Display for Multiple {
             oxiplate_formatter
                 .write_str(
                     &alloc::string::ToString::to_string(
-                        &(crate::filters_for_oxiplate::shorten(
-                            crate::filters_for_oxiplate::respond(self.message, false),
+                        &(filters_for_oxiplate::shorten(
+                            filters_for_oxiplate::respond(self.message, false),
                             self.length,
                         )),
                     ),
@@ -513,14 +504,14 @@ impl ::core::fmt::Display for Trim {
             oxiplate_formatter
                 .write_str(
                     &alloc::string::ToString::to_string(
-                        &(crate::filters_for_oxiplate::trim(self.value)),
+                        &(filters_for_oxiplate::trim(self.value)),
                     ),
                 )?;
             oxiplate_formatter.write_str(" ")?;
             oxiplate_formatter
                 .write_str(
                     &alloc::string::ToString::to_string(
-                        &(crate::filters_for_oxiplate::trim(self.value)),
+                        &(filters_for_oxiplate::trim(self.value)),
                     ),
                 )?;
             string
@@ -588,7 +579,7 @@ impl ::core::fmt::Display for Replace {
             oxiplate_formatter
                 .write_str(
                     &alloc::string::ToString::to_string(
-                        &(crate::filters_for_oxiplate::replace(self.value, "ar", "oo")),
+                        &(filters_for_oxiplate::replace(self.value, "ar", "oo")),
                     ),
                 )?;
             string

--- a/oxiplate/src/lib.rs
+++ b/oxiplate/src/lib.rs
@@ -39,6 +39,8 @@ pub use oxiplate_traits::{
 ///
 ///     use oxiplate::{Oxiplate, Render};
 ///
+///     use crate::filters_for_oxiplate;
+///
 ///     #[derive(Oxiplate)]
 ///     #[oxiplate_inline(html: r#"{{ "Hello World" | lower() }}"#)]
 ///     struct Data;

--- a/oxiplate/tests/expansion/expected/default.rs
+++ b/oxiplate/tests/expansion/expected/default.rs
@@ -36,7 +36,7 @@ impl ::oxiplate::Render for Data {
         use ::oxiplate::{ToCowStr as _, UnescapedText as _};
         oxiplate_formatter.write_str("\n<!DOCTYPE html>\n<title>")?;
         (&&::oxiplate::UnescapedTextWrapper::new(
-            &(crate::filters_for_oxiplate::default(self.title, "Default title")),
+            &(filters_for_oxiplate::default(self.title, "Default title")),
         ))
             .oxiplate_escape(
                 oxiplate_formatter,

--- a/oxiplate/tests/expansion/expected/filters.rs
+++ b/oxiplate/tests/expansion/expected/filters.rs
@@ -75,7 +75,7 @@ impl ::oxiplate::Render for Respond {
         (&&::oxiplate::UnescapedTextWrapper::new(
             &(::oxiplate::CowStrWrapper::new(
                 (&&::oxiplate::ToCowStrWrapper::new(
-                    &(crate::filters_for_oxiplate::respond(
+                    &(filters_for_oxiplate::respond(
                         ::oxiplate::CowStrWrapper::new(
                             (&&::oxiplate::ToCowStrWrapper::new(&(self.message)))
                                 .to_cow_str(),
@@ -179,7 +179,7 @@ impl ::oxiplate::Render for Shorten {
         use ::core::fmt::Write as _;
         use ::oxiplate::{ToCowStr as _, UnescapedText as _};
         (&&::oxiplate::UnescapedTextWrapper::new(
-            &(crate::filters_for_oxiplate::shorten(
+            &(filters_for_oxiplate::shorten(
                 ::oxiplate::CowStrWrapper::new(
                     (&&::oxiplate::ToCowStrWrapper::new(&(self.message))).to_cow_str(),
                 ),
@@ -293,7 +293,7 @@ impl ::oxiplate::Render for Pad {
         use ::core::fmt::Write as _;
         use ::oxiplate::{ToCowStr as _, UnescapedText as _};
         (&&::oxiplate::UnescapedTextWrapper::new(
-            &(crate::filters_for_oxiplate::pad(self.number, self.length)),
+            &(filters_for_oxiplate::pad(self.number, self.length)),
         ))
             .oxiplate_raw(oxiplate_formatter)?;
         Ok(())
@@ -386,10 +386,10 @@ impl ::oxiplate::Render for Multiple {
         use ::core::fmt::Write as _;
         use ::oxiplate::{ToCowStr as _, UnescapedText as _};
         (&&::oxiplate::UnescapedTextWrapper::new(
-            &(crate::filters_for_oxiplate::shorten(
+            &(filters_for_oxiplate::shorten(
                 ::oxiplate::CowStrWrapper::new(
                     (&&::oxiplate::ToCowStrWrapper::new(
-                        &(crate::filters_for_oxiplate::respond(
+                        &(filters_for_oxiplate::respond(
                             ::oxiplate::CowStrWrapper::new(
                                 (&&::oxiplate::ToCowStrWrapper::new(&(self.message)))
                                     .to_cow_str(),


### PR DESCRIPTION
`filters_for_oxiplate` was intended to be imported in a similar fashion to `Oxiplate` itself. The documentation already described it in this manner, but the implementation differed from that. This fixes the code generation to look in the current module for `filters_for_oxiplate` instead.